### PR TITLE
Fix supabase client defaults

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,1 +1,7 @@
 import '$lib/supabaseClient';
+
+// In newer versions of SvelteKit a `handleError` hook is expected on the
+// client. Without this export the build fails when `app` tries to import it.
+export const handleError = ({ error }: { error: unknown }) => {
+	console.error(error);
+};

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -3,9 +3,13 @@ import { SSE } from 'sse.js';
 
 import type { ChatModel, Message } from '$lib/types/chatTypes';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseFunctionsUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Provide sane defaults so that the app can start even if the environment
+// variables are missing (for example when running tests). `createClient`
+// throws if it receives empty strings, so fall back to local values.
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'http://localhost:54321';
+const supabaseFunctionsUrl =
+	import.meta.env.VITE_SUPABASE_FUNCTIONS_URL || 'http://localhost:54321/functions/v1';
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'public-anon-key';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Summary
- handle missing env vars for supabase client so builds don't fail
- export `handleError` from `hooks.client.ts`

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68427a8d36508324b19697187a55e17b