### PR TITLE
Fix Supabase pagination range

### DIFF
--- a/src/lib/helpers/pagination.ts
+++ b/src/lib/helpers/pagination.ts
@@ -4,10 +4,15 @@ export const supabasePaginationDefaults = {
 	amounts: [1, 5, 20]
 };
 
-export const getFromTo = (page: number, size: number) => {
-	const limit = size ? +size : supabasePaginationDefaults.limit;
-	const from = page ? page * limit : supabasePaginationDefaults.offset;
-	const to = page ? from + size : size;
+/**
+ * Calculate the range for Supabase queries using an offset and limit.
+ * @param {number} offset - Zero based starting index.
+ * @param {number} limit - Amount of records to fetch.
+ */
+export const getFromTo = (offset: number, limit: number) => {
+	const _limit = isNaN(limit) ? supabasePaginationDefaults.limit : +limit;
+	const from = isNaN(offset) ? supabasePaginationDefaults.offset : offset;
+	const to = from + _limit - 1;
 
 	return { from, to };
 };


### PR DESCRIPTION
## Summary
- treat first parameter in pagination util as offset
- compute `from` and `to` accordingly

## Testing
- `npm run lint` *(fails: code style issues in unrelated files)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68427f84852c8324a7a568420ceaf107